### PR TITLE
userStore의 State와 Actions를 분리하고 update 함수 추가

### DIFF
--- a/store/userStore.tsx
+++ b/store/userStore.tsx
@@ -1,19 +1,28 @@
 import { create } from 'zustand';
 
-interface UserState {
+type State = {
   username: string;
   password: string;
   passwordConfirm: string;
   nickname: string;
   bio: string | null;
-  setUsername: (username: string) => void;
-  setPassword: (password: string) => void;
-  setPasswordConfirm: (passwordConfirm: string) => void;
-  setNickname: (nickname: string) => void;
-  setBio: (bio: string) => void;
-}
+};
 
-const userStore = create<UserState>((set) => ({
+type Actions = {
+  setUsername: (username: State['username']) => void;
+  setPassword: (password: State['password']) => void;
+  setPasswordConfirm: (passwordConfirm: State['passwordConfirm']) => void;
+  setNickname: (nickname: State['nickname']) => void;
+  setBio: (bio: State['bio']) => void;
+
+  updateUsername: (username: State['username']) => void;
+  updatePassword: (password: State['password']) => void;
+  updatePasswordConfirm: (passwordConfirm: State['passwordConfirm']) => void;
+  updateNickname: (nickname: State['nickname']) => void;
+  updateBio: (bio: State['bio']) => void;
+};
+
+const userStore = create<State & Actions>((set) => ({
   username: '',
   password: '',
   passwordConfirm: '',
@@ -24,6 +33,12 @@ const userStore = create<UserState>((set) => ({
   setPasswordConfirm: (passwordConfirm) => set({ passwordConfirm }),
   setNickname: (nickname) => set({ nickname }),
   setBio: (bio) => set({ bio }),
+
+  updateUsername: (username) => set({ username }),
+  updatePassword: (password) => set({ password }),
+  updatePasswordConfirm: (passwordConfirm) => set({ passwordConfirm }),
+  updateNickname: (nickname) => set({ nickname }),
+  updateBio: (bio) => set({ bio }),
 }));
 
 export default userStore;


### PR DESCRIPTION
# 상황
userStore에서 속성과 함수가 하나의 인터페이스로 되어 있었습니다.

# 행위
속성과 함수 개별관리를 위해 속성은 State로, 함수는 Action으로 분리했습니다.
update 함수들을 추가했습니다.