### PR TITLE
포스트 카드에서 제목, 내용 미리보기 텍스트 수 제한 적용

### DIFF
--- a/components/PostCard.tsx
+++ b/components/PostCard.tsx
@@ -5,9 +5,13 @@ const PostCard = ({ post }: { post: any }) => {
     <div className="gap-4">
       <li className="blog-card flex flex-col w-full h-full text-titleColor">
         <div className="flex justify-center items-center text-center w-full h-[48px] border-b-[1px] border-b-slate-200 text-[18px] overflow-hidden">
-          {post.title}
+          {Array.from(Array(10).keys()).map((i) => post.title[i])}
+          {post.title.length > 10 ? ' ...' : null}
         </div>
-        <div className="text-[16px] h-[210px] m-2 overflow-hidden">{post.content}</div>
+        <div className="text-[16px] h-[210px] m-2 overflow-hidden">
+          {Array.from(Array(200).keys()).map((i) => post.content[i])}
+          {post.content.length > 200 ? ' ...' : null}
+        </div>
         <footer className="flex items-center justify-between w-full h-12 text-left p-4 text-[14px] border-t-[1px] border-t-slate-200">
           <div className="pr-4">by {post.author}</div>
           <div className="flex items-center gap-1">


### PR DESCRIPTION
# 문제발견
포스트 미리보기에서 제목과 내용이 글자 수가 많으면 카드 밖을 벗어나서 보여졌습니다.

# 원인분석
미리 보기에서 글자 수 제한을 따로 두지 않고 전체가 보여지도록 했습니다.

# 해결
글자 수 제한을 두고 특정 글자 수 이상이면 부분만 보여지도록 수정했습니다.